### PR TITLE
Fix detection of deleted and removed comments when browser language is not English

### DIFF
--- a/src/api/reddit/index.js
+++ b/src/api/reddit/index.js
@@ -1,6 +1,7 @@
 import { fetchJson, chunk } from '../../utils'
 
 const baseURL = 'https://api.reddit.com'
+const requestSettings = {headers: {"Accept-Language": "en"}}
 
 const errorHandler = (error, from) => {
   console.error(from + ': ' + error)
@@ -9,7 +10,7 @@ const errorHandler = (error, from) => {
 
 // Return the post itself
 export const getPost = (subreddit, threadID) => (
-  fetchJson(`${baseURL}/comments/${threadID}.json?limit=1`)
+  fetchJson(`${baseURL}/comments/${threadID}.json?limit=1`, requestSettings)
     .then(thread => thread[0].data.children[0].data)
     .catch(error => errorHandler(error, 'reddit.getPost'))
 )
@@ -23,7 +24,7 @@ export const getPost = (subreddit, threadID) => (
 
 // Helper function that fetches a list of comments
 const fetchComments = (commentIDs) => (
-  fetchJson(`${baseURL}/api/info?id=${commentIDs.map(id => `t1_${id}`).join()}`)
+  fetchJson(`${baseURL}/api/info?id=${commentIDs.map(id => `t1_${id}`).join()}`, requestSettings)
     .then(results => results.data.children.map(({data}) => data))
 )
 


### PR DESCRIPTION
See JubbeArt#41.

When the browser language is set to something other than English, the Reddit API translates `[deleted]` and `[removed]` in its responses, breaking the detection of deleted and removed comments. This is a very simple fix to force them to be in English. An alternative would be to add detection for all languages supported by Reddit, but that seems like unnecessary work.